### PR TITLE
Docker

### DIFF
--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -994,6 +994,7 @@ class Client:
                         + res["na"][server_dict['na'][0]]['name']
                         + " Prior query states may not be accessible."
                     )
+                    self.naServerID = server_dict['na'][0]
         else:
             raise RuntimeError("NeuroArch Server with {} dataset cannot be found. Available dataset on the FFBO processor is the following \n{}\n.If you are running the NeuroArch server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, ', '.join(valid_datasets)))
             # print(

--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -515,7 +515,7 @@ class Client:
                                               challenge.extra['salt'],
                                               challenge.extra['iterations'],
                                               challenge.extra['keylen'])
-                        print(salted_key.decode('utf-8'))
+                        #print(salted_key.decode('utf-8'))
 
                 # compute signature for challenge, using the key
                 signature = auth.compute_wcs(salted_key, challenge.extra["challenge"])
@@ -1016,6 +1016,10 @@ class Client:
             #     printHeader("FFBOLab Client")
             #     + "NLP Server with {} dataset not found".format(dataset)
             # )
+
+        if len(res["nk"]) == 0:
+            Warning("Neurokernel Server not found on the FFBO processor. Circuit execution on the server side is not supported.")
+
 
     def get_client_info(self, fbl=None):
         """Receive client data for this client only.
@@ -2722,10 +2726,11 @@ class Client:
         res = self.client.session.call(u'ffbo.processor.server_information')
         if len(res['nk']) == 0:
             raise RuntimeError('Neurokernel Server not found. If it halts, please restart it.')
+        # TODO: randomly choose from the nk servers that are not busy. If all are busy, randomly choose one.
         msg = {#'neuron_list': labels,
                 "user": self.client._async_session._session_id,
                 "name": name,
-                "servers": {'na': self.naServerID, 'nk': list(res['nk'].keys())[0]}}
+                "servers": {'na': self.naServerID, 'nk': random.choice(list(res['nk'].keys()))}}
 
         if len(inputProcessors)>0:
             msg['inputProcessors'] = inputProcessors

--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -924,7 +924,7 @@ class Client:
                 server_dict[server_config['dataset']]['nlp'].append(server_id)
             valid_datasets = []
             for dataset_name, server_lists in server_dict.items():
-                if len(server_list['na']) and len(server_list['nlp']):
+                if len(server_lists['na']) and len(server_lists['nlp']):
                     valid_datasets.append(dataset_name)
             if len(valid_datasets):
                 print(

--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -916,26 +916,28 @@ class Client:
         print(res)
 
         default_mode = False
+
+        server_dict = {}
+        for server_id, server_config in res["na"].items():
+            if 'dataset' not in server_config:
+                server_config['dataset'] = 'default'
+                default_mode = True
+            if server_config['dataset'] not in server_dict:
+                server_dict[server_config['dataset']] = {'na': [], 'nlp': []}
+            server_dict[server_config['dataset']]['na'].append(server_id)
+        for server_id, server_config in res["nlp"].items():
+            if 'dataset' not in server_config:
+                server_config['dataset'] = 'default'
+                default_mode = True
+            if server_config['dataset'] not in server_dict:
+                server_dict[server_config['dataset']] = {'na': [], 'nlp': []}
+            server_dict[server_config['dataset']]['nlp'].append(server_id)
+        valid_datasets = []
+        for dataset_name, server_lists in server_dict.items():
+            if len(server_lists['na']) and len(server_lists['nlp']):
+                valid_datasets.append(dataset_name)
+
         if dataset is None:
-            server_dict = {}
-            for server_id, server_config in res["na"].items():
-                if 'dataset' not in server_config:
-                    server_config['dataset'] = 'default'
-                    default_mode = True
-                if server_config['dataset'] not in server_dict:
-                    server_dict[server_config['dataset']] = {'na': [], 'nlp': []}
-                server_dict[server_config['dataset']]['na'].append(server_id)
-            for server_id, server_config in res["nlp"].items():
-                if 'dataset' not in server_config:
-                    server_config['dataset'] = 'default'
-                    default_mode = True
-                if server_config['dataset'] not in server_dict:
-                    server_dict[server_config['dataset']] = {'na': [], 'nlp': []}
-                server_dict[server_config['dataset']]['nlp'].append(server_id)
-            valid_datasets = []
-            for dataset_name, server_lists in server_dict.items():
-                if len(server_lists['na']) and len(server_lists['nlp']):
-                    valid_datasets.append(dataset_name)
             if default_mode:
                 if len(valid_datasets):
                     pass
@@ -945,7 +947,7 @@ class Client:
                 if len(valid_datasets) == 1:
                     dataset = valid_dataset[0]
                 elif len(valid_datasets) > 1:
-                    raise RuntimeError("Multiple . Available dataset on the FFBO processor is the following \n{}\n.If you are running the NeuroArch server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, ', '.join(valid_datasets)))
+                    raise RuntimeError("Multiple . Available dataset on the FFBO processor is the following:{}\nIf you are running the NeuroArch server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, '\n- '.join(valid_datasets)))
                 # print(
                 #     printHeader("FFBOLab Client")
                 #     + "Found following datasets: "
@@ -996,7 +998,7 @@ class Client:
                     )
                     self.naServerID = server_dict['na'][0]
         else:
-            raise RuntimeError("NeuroArch Server with {} dataset cannot be found. Available dataset on the FFBO processor is the following \n{}\n.If you are running the NeuroArch server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, ', '.join(valid_datasets)))
+            raise RuntimeError("NeuroArch Server with {} dataset cannot be found. Available dataset on the FFBO processor is the following:{}\nIf you are running the NeuroArch server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, '\n- '.join(valid_datasets)))
             # print(
             #     printHeader("FFBOLab Client")
             #     + "NA Server with {} dataset not found".format(dataset)
@@ -1009,7 +1011,7 @@ class Client:
             )
             self.nlpServerID = server_dict['nlp'][0]
         else:
-            raise RuntimeError("NeuroNLP Server with {} dataset cannot be found. Available dataset on the FFBO processor is the following \n{}\n.If you are running the NeuroNLP server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, ', '.join(valid_datasets)))
+            raise RuntimeError("NeuroNLP Server with {} dataset cannot be found. Available dataset on the FFBO processor is the following:{}\nIf you are running the NeuroNLP server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, '\n- '.join(valid_datasets)))
             # print(
             #     printHeader("FFBOLab Client")
             #     + "NLP Server with {} dataset not found".format(dataset)

--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -947,7 +947,7 @@ class Client:
                 if len(valid_datasets) == 1:
                     dataset = valid_dataset[0]
                 elif len(valid_datasets) > 1:
-                    raise RuntimeError("Multiple . Available dataset on the FFBO processor is the following:{}\nIf you are running the NeuroArch server locally, please check if the server is on and connected. If you are connecting to a public server, please contact server admin.".format(dataset, '\n- '.join(valid_datasets)))
+                    raise RuntimeError("Multiple valid datasets are available on the specified FFBO processor. However, you did not specify which dataset to connect to. Available datasets on the FFBO processor are the following:{}\n. Please choose one of the above datasets during Client connection by passing the dataset argument.".format('\n- '.join(valid_datasets)))
                 # print(
                 #     printHeader("FFBOLab Client")
                 #     + "Found following datasets: "

--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -917,10 +917,14 @@ class Client:
         if dataset is None:
             server_dict = {}
             for server_id, server_config in res["na"].items():
+                if 'dataset' not in server_config:
+                    server_config['dataset'] = 'default'
                 if server_config['dataset'] not in server_dict:
                     server_dict[server_config['dataset']] = {'na': [], 'nlp': []}
                 server_dict[server_config['dataset']]['na'].append(server_id)
             for server_id, server_config in res["nlp"].items():
+                if 'dataset' not in server_config:
+                    server_config['dataset'] = 'default'
                 if server_config['dataset'] not in server_dict:
                     server_dict[server_config['dataset']] = {'na': [], 'nlp': []}
                 server_dict[server_config['dataset']]['nlp'].append(server_id)
@@ -947,11 +951,19 @@ class Client:
         else:
             server_dict = {'na': [], 'nlp': []}
             for server_id, server_config in res["na"].items():
-                if server_config['dataset'] == dataset:
+                if 'dataset' in server_config:
+                    if server_config['dataset'] == dataset:
+                        server_dict['na'].append(server_id)
+                else:
                     server_dict['na'].append(server_id)
+                    break
             for server_id, server_config in res["nlp"].items():
-                if server_config['dataset'] == dataset:
+                if 'dataset' in server_config:
+                    if server_config['dataset'] == dataset:
+                        server_dict['nlp'].append(server_id)
+                else:
                     server_dict['nlp'].append(server_id)
+                    break
             if len(server_dict['na']):
                 if self.naServerID is None:
                     print(

--- a/flybrainlab/Client.py
+++ b/flybrainlab/Client.py
@@ -359,8 +359,8 @@ class Client:
             if not configured:
                 raise Exception("No config file exists for this component")
 
-            user = config["GUEST"]["user"]
-            secret = config["GUEST"]["secret"]
+            user = config["USER"]["user"]
+            secret = config["USER"]["secret"]
             ssl = eval(config["AUTH"]["ssl"])
             websockets = "wss" if ssl else "ws"
             if "ip" in config["SERVER"]:
@@ -401,8 +401,8 @@ class Client:
             if not configured:
                 raise Exception("No config file exists for this component")
 
-            user = config["GUEST"]["user"]
-            secret = config["GUEST"]["secret"]
+            user = config["USER"]["user"]
+            secret = config["USER"]["secret"]
             ssl = eval(config["AUTH"]["ssl"])
             websockets = "wss" if ssl else "ws"
             if "ip" in config["SERVER"]:
@@ -410,7 +410,7 @@ class Client:
             else:
                 ip = "localhost"
             if "port" in config["SERVER"]:
-                port = int(config["NLP"]['expose-port'])
+                port = int(config["SERVER"]["port"])
                 url =  "{}://{}:{}/ws".format(websockets, ip, port)
             else:
                 url =  u"{}://{}/ws".format(websockets, ip)
@@ -418,6 +418,8 @@ class Client:
             realm = config["SERVER"]["realm"]
             # authentication = eval(config["AUTH"]["authentication"])
             ssl = False # override ssl for connections
+            if 'dataset' in config["SERVER"]:
+                dataset = config["SERVER"]['dataset']
         # end of temporary fix
         self.url = url
         self.FFBOLabcomm = FFBOLabcomm # Current Communications Object
@@ -935,7 +937,7 @@ class Client:
                 print(
                     printHeader("FFBOLab Client")
                     + "Please choose a dataset from the above valid datasets by"
-                    + ".findServerIDs(dataset = 'name')"
+                    + " Client.findServerIDs(dataset = 'any name above')"
                 )
             else:
                 print(

--- a/flybrainlab/NeurokernelComponent.py
+++ b/flybrainlab/NeurokernelComponent.py
@@ -600,6 +600,7 @@ class ffbolabComponent:
         ca_cert_file="isrgrootx1.pem",
         intermediate_cert_file="letsencryptauthorityx3.pem",
         FFBOLabcomm=None,
+        server_name = 'nk',
     ):
         if os.path.exists(os.path.join(home, ".ffbolab", "lib")):
             print(
@@ -714,7 +715,7 @@ class ffbolabComponent:
             u"ffbo.server.register",
             FFBOLABClient._async_session._session_id,
             "nk",
-            "nk_server",
+            {"name": server_name, "version": 1.05},
         )
         print("Registered self...")
 

--- a/flybrainlab/NeurokernelComponent.py
+++ b/flybrainlab/NeurokernelComponent.py
@@ -228,7 +228,7 @@ class neurokernel_server(object):
             for kkey, lpu in lpus.items():
                 graph = lpu['graph']
 
-                for uid, comp in graph.node.items():
+                for uid, comp in graph.nodes.items():
                     if 'attr_dict' in comp:
                         print('Found attr_dict; fixing...')
                         nx.set_node_attributes(graph, {uid: comp['attr_dict']})
@@ -270,7 +270,7 @@ class neurokernel_server(object):
                 lpu_name = k
                 graph = lpu['graph']
 
-                for uid, comp in graph.node.items():
+                for uid, comp in graph.nodes.items():
                     if 'attr_dict' in comp:
                         nx.set_node_attributes(graph, {uid: comp['attr_dict']})
                         # print('changed',uid)
@@ -283,7 +283,7 @@ class neurokernel_server(object):
                 # nx.write_gexf(graph,'name.gexf')
                 # with open(lpu_name + '.pickle', 'wb') as f:
                 #     pickle.dump(graph, f, protocol=pickle.HIGHEST_PROTOCOL)
-                comps =  graph.node.items()
+                comps =  graph.nodes.items()
 
                 #for uid, comp in comps:
                 #    if 'attr_dict' in comp:

--- a/flybrainlab/nk_component_runner.py
+++ b/flybrainlab/nk_component_runner.py
@@ -1,6 +1,7 @@
 from flybrainlab.NeurokernelComponent import *
 import time
 from configparser import ConfigParser
+import argparse
 
 if __name__ == "__main__":
     import neurokernel.mpi_relaunch
@@ -10,6 +11,12 @@ if __name__ == "__main__":
     import OpenSSL.crypto
 
     from configparser import ConfigParser
+
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--name', dest='name', type=str, default = 'nk',
+                    help='Name of the server')
+    args = parser.parse_args()
 
     root = os.path.expanduser("/")
     home = os.path.expanduser("~")
@@ -50,7 +57,7 @@ if __name__ == "__main__":
 
     Component = ffbolabComponent(user = user, secret=secret, url = url, ssl = ssl, debug = debug, realm = realm,
                                  ca_cert_file = ca_cert_file, intermediate_cert_file = intermediate_cert_file,
-                                 authentication = authentication)
+                                 authentication = authentication, server_name = args.name)
     server = neurokernel_server()
 
     print(printHeader("FFBO Neurokernel Component") + "Connection successful.")


### PR DESCRIPTION
Adding `dataset` argument in `Client` to connect to a pair of NA/NLP servers of the specified dataset, enabled by updates in `ffbo.processor` starting from commit `ce5aeb5`, `ffbo.neuroarch_component` from commit `b78f59a9f`, `ffbo.nlp_component` from commit `19271d864`.

In `custome_config`, `port` now needs to be configured in the `['SERVER']['port']` instead of `['NLP']['expose-port']`.