### PR TITLE
Sendmodel

### DIFF
--- a/flybrainlab/widget.py
+++ b/flybrainlab/widget.py
@@ -203,5 +203,6 @@ class WidgetManager(object):
     def send_data(self, widget_id, data):
         if widget_id in self.widgets:
             self.widgets[widget_id].send_data(data)
+            self.last_active = self.widgets[widget_id]
 
 


### PR DESCRIPTION
A few changes are added to widget_manager

1. an additional attribute of `last_active` keeps track the last active widget in the following sequence:
     - if no comm has been sent/received yet, keeps track of last added widget (in `add_widget`)
     - if comm has been sent/received, change to track the widget that comm is associated with
2. Widget instances now have a `parse_data` method, which parse `comm_data` that's received on comm.
     - if `comm_data` follows `{messageType: str, data: dict}` syntax, we check if `messageType == 'model'` which means `comm_data['data']` is the `model` of the front-end widget. we then store the model in widget on the kernel side.
2. on comm message, `widget.parse_data` method is called.
2. Widget's `__repr__` now hides `model, msg_data` attributes since they can be very large
